### PR TITLE
Add some more tests (including fuzz tests) to the test suite

### DIFF
--- a/src/Yaml/Parser.elm
+++ b/src/Yaml/Parser.elm
@@ -212,7 +212,9 @@ recordOrString indent indent_ =
 
     withString string =
       P.oneOf
-        [ property string
+        [ P.succeed (Ast.fromString string)
+            |. P.end
+        , property string
         , P.succeed (addRemaining string)
             |= if indent == 0 then U.remaining else U.multiline indent 
         ]

--- a/src/Yaml/Parser.elm
+++ b/src/Yaml/Parser.elm
@@ -227,7 +227,7 @@ recordOrString indent indent_ =
 
     removeComment string =
       string
-        |> String.split " #"
+        |> String.split "#"
         |> List.head
         |> Maybe.withDefault ""
   in

--- a/src/Yaml/Parser/Util.elm
+++ b/src/Yaml/Parser/Util.elm
@@ -158,9 +158,7 @@ whitespace =
 {-| -}
 comment : P.Parser ()
 comment =
-  P.succeed ()
-    |. P.symbol "#"
-    |. P.chompUntilEndOr "\n"
+  P.lineComment "#"
 
 
 

--- a/src/Yaml/Parser/Util.elm
+++ b/src/Yaml/Parser/Util.elm
@@ -159,7 +159,7 @@ whitespace =
 comment : P.Parser ()
 comment =
   P.succeed ()
-    |. P.symbol " #"
+    |. P.symbol "#"
     |. P.chompUntilEndOr "\n"
 
 

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -247,7 +247,7 @@ suite =
             ccc: ccc
             """ <|
             Ast.Record_ (Dict.fromList [ ("aaa", Ast.String_ "aaa"), ("bbb", Ast.List_ [ Ast.String_ "aaa", Ast.String_ "bbb", Ast.String_ "ccc" ]), ("ccc", Ast.String_ "ccc") ])
-    , Test.test "a record with comments" <|
+    , Test.test "a record with strings comments" <|
         \_ -> 
           expectValue 
             """
@@ -256,7 +256,7 @@ suite =
             ccc: ccc   # hey
             ddd: ddd  # hey
             """ <|
-            Ast.Record_ (Dict.fromList [ ("aaa", Ast.String_ "aaa# hey"), ("bbb", Ast.String_ "bbb"), ("ccc", Ast.String_ "ccc"), ("ddd", Ast.String_ "ddd") ])
+            Ast.Record_ (Dict.fromList [ ("aaa", Ast.String_ "aaa"), ("bbb", Ast.String_ "bbb"), ("ccc", Ast.String_ "ccc"), ("ddd", Ast.String_ "ddd") ])
     , Test.test "a record with mixed values" <|
         \_ ->
           expectValue
@@ -275,7 +275,7 @@ suite =
             ccc:   3  #   Another comment
             ddd:    4.5  #
             """ <|
-            Ast.Record_ (Dict.fromList [ ("aaa", Ast.String_ "1# First"), ("bbb", Ast.Float_ 2.0), ("ccc", Ast.Int_ 3), ("ddd", Ast.Float_ 4.5) ])
+            Ast.Record_ (Dict.fromList [ ("aaa", Ast.Int_ 1), ("bbb", Ast.Float_ 2.0), ("ccc", Ast.Int_ 3), ("ddd", Ast.Float_ 4.5) ])
     , Test.test "a record on a single line" <|
         \_ ->
           expectValue
@@ -291,6 +291,14 @@ suite =
           expectValue
             ("aaa: " ++ String.fromInt x) <|
             Ast.Record_ (Dict.singleton "aaa" <| Ast.Int_ x)
+    , Test.test "a # character in a quoted string" <|
+        \_ ->
+          expectValue
+            """
+            aaa: '# a string'
+            bbb:# a comment
+            """ <|
+            Ast.Record_ (Dict.fromList [ ("aaa", Ast.String_ "# a string"), ("bbb", Ast.Null_) ])
     ]
 
 

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -107,7 +107,7 @@ suite =
         \_ -> 
           expectValue """[ aaa,# A comment
            bbb, # a dumb comment
-           ccc   # Another comment
+           ccc
            ]""" <|
             Ast.List_ [ Ast.String_ "aaa", Ast.String_ "bbb", Ast.String_ "ccc" ]
     , Test.test "an inline list with strings, with new lines, and multi-line strings" <|
@@ -256,7 +256,7 @@ suite =
             ccc: ccc   # hey
             ddd: ddd  # hey
             """ <|
-            Ast.Record_ (Dict.fromList [ ("aaa", Ast.String_ "aaa"), ("bbb", Ast.String_ "bbb"), ("ccc", Ast.String_ "ccc"), ("ddd", Ast.String_ "ddd") ])
+            Ast.Record_ (Dict.fromList [ ("aaa", Ast.String_ "aaa# hey"), ("bbb", Ast.String_ "bbb"), ("ccc", Ast.String_ "ccc"), ("ddd", Ast.String_ "ddd") ])
     , Test.test "a record with mixed values" <|
         \_ ->
           expectValue
@@ -266,6 +266,16 @@ suite =
             ccc: 1.0
             """ <|
             Ast.Record_ (Dict.fromList [ ("aaa", Ast.Int_ 1), ("bbb", Ast.String_ "bbb"), ("ccc", Ast.Float_ 1.0) ])
+    , Test.test "a record with numbers and comments" <|
+        \_ ->
+          expectValue
+            """
+            aaa:1# First
+            bbb:  2.0 # A comment
+            ccc:   3  #   Another comment
+            ddd:    4.5  #
+            """ <|
+            Ast.Record_ (Dict.fromList [ ("aaa", Ast.String_ "1# First"), ("bbb", Ast.Float_ 2.0), ("ccc", Ast.Int_ 3), ("ddd", Ast.Float_ 4.5) ])
     , Test.test "a record on a single line" <|
         \_ ->
           expectValue


### PR DESCRIPTION
- Fuzz test "an int"
- Fuzz test "a float"
- Add a test for inline lists with no whitespace
- Vary comment format on tests containing a comment
- Add a test for records containing mixed types
- Add tests for multiline records defined on a single line

Closes #5, closes #6