### PR TITLE
Records seperators (:) must have trailing whitespace

### DIFF
--- a/src/Yaml/Parser.elm
+++ b/src/Yaml/Parser.elm
@@ -334,7 +334,11 @@ quotedString indent =
 recordProperty : Int -> String -> P.Parser Ast.Value
 recordProperty indent name =
     P.succeed (record indent name)
-        |. P.chompIf U.isColon
+        |. P.oneOf
+            [ P.token ": "
+            , P.token ":\n"
+            , P.backtrackable (P.token ":") |. P.end
+            ]
         |> P.andThen identity
 
 
@@ -478,6 +482,7 @@ recordInlinePropertyNameString =
     -- TODO allow numeric name
     P.succeed ()
         |. P.chompWhile (U.neither3 U.isColon U.isComma U.isRecordEnd)
+        |. U.whitespace
         |> P.getChompedString
         |> P.map String.trim
 

--- a/src/Yaml/Parser/Util.elm
+++ b/src/Yaml/Parser/Util.elm
@@ -166,9 +166,9 @@ whitespace =
                 [ P.succeed (P.Loop ())
                     |. comment
                 , P.succeed (P.Loop ())
-                    |. P.chompIf isSpace
+                    |. P.symbol " "
                 , P.succeed (P.Loop ())
-                    |. P.chompIf isNewLine
+                    |. P.symbol "\n"
                 , P.succeed (P.Done ())
                 ]
     in

--- a/tests/TestDecoder.elm
+++ b/tests/TestDecoder.elm
@@ -69,6 +69,8 @@ suite =
                 \_ -> given "true" Yaml.string |> expectFail "Expected string, got: True (bool)"
             , Test.fuzz (Fuzz.map sanitiseString string) "random string" <|
                 \s -> given s Yaml.string |> expectEqual (String.trim s)
+            , Test.test "string continaing a colon with no trailing space" <|
+                \_ -> given "a:b" Yaml.string |> expectEqual "a:b"
             ]
         , Test.describe "boolean values"
             [ Test.test "boolean true" <|

--- a/tests/TestParser.elm
+++ b/tests/TestParser.elm
@@ -50,7 +50,7 @@ suite =
         , Test.test "a single-quoted string" <|
             \_ ->
                 -- TODO is this right?
-                expectValue """'hey 
+                expectValue """'hey
           i am a 
 
           parser'""" <|
@@ -60,8 +60,8 @@ suite =
                 expectErr "'hello"
         , Test.test "a double-quoted string" <|
             \_ ->
-                expectValue """"hey 
-          i am a 
+                expectValue """"hey
+          i am a
           parser" """ <|
                     Ast.String_ "hey i am a parser"
         , Test.test "a double-quoted string with no closing quote" <|
@@ -70,6 +70,9 @@ suite =
         , Test.test "a string containing a colon" <|
             \_ ->
                 expectValue ":!" <| Ast.String_ ":!"
+        , Test.test "another string containing a colon" <|
+            \_ ->
+                expectValue "a:b" <| Ast.String_ "a:b"
         , Test.test "a single-line string" <|
             \_ ->
                 expectValue "hey i am a parser" <|
@@ -365,7 +368,7 @@ suite =
             \_ ->
                 expectValue
                     """
-            aaa:1# First
+            aaa: 1# First
             bbb:  2.0 # A comment
             ccc:   3  #   Another comment
             ddd:    4.5  #
@@ -381,7 +384,7 @@ suite =
         , Test.test "a record on a single line with a quoted value" <|
             \_ ->
                 expectValue
-                    "aaa:'aaa'"
+                    "aaa: 'aaa'"
                 <|
                     Ast.Record_ (Dict.singleton "aaa" <| Ast.String_ "aaa")
         , Test.fuzz int "a record on a single line with an integer value" <|


### PR DESCRIPTION
If a string contains a colon with no trailing whitespace it should not be interpreted as a mapping.

Closes #16