### PR TITLE
Fix for empty string decoding as a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ## Fixed
 - A bug causing strings containing a colon to be interpreted as a mapping.
+- A bug causing the list decoder to fail on empty strings.
 
 ## [1.1.0]
 ### Added

--- a/src/Yaml/Decode.elm
+++ b/src/Yaml/Decode.elm
@@ -288,6 +288,9 @@ list decoder =
                 Ast.List_ list_ ->
                     singleResult (List.map (fromValue decoder) list_)
 
+                Ast.Null_ ->
+                    Ok []
+
                 _ ->
                     decodeError "list" v
 

--- a/tests/TestDecoder.elm
+++ b/tests/TestDecoder.elm
@@ -199,6 +199,8 @@ suite =
         , Test.describe "lists"
             [ Test.test "empty list" <|
                 \_ -> given "[]" (Yaml.list Yaml.null) |> expectEqual []
+            , Test.test "decode nothing into an empty list" <|
+                \_ -> given "" (Yaml.list Yaml.int) |> expectEqual []
             , Test.fuzz (list int) "list of integers" <|
                 \xs ->
                     let


### PR DESCRIPTION
An empty string should still decode to an empty list
using the list decoder.

Closes #19.

Thanks to @tad-lispy for contributing this fix.