### PR TITLE
When encoding record elements, check if indentation is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Updated `elm-explorations/test` to version 2 ([#30](https://github.com/MaybeJustJames/yaml/pull/30)
+- Incorrect encoding of empty collection values in records ([#33](https://github.com/MaybeJustJames/yaml/pull/33))
 
 ## [2.1.2]
 ### Changed

--- a/src/Yaml/Encode.elm
+++ b/src/Yaml/Encode.elm
@@ -461,9 +461,19 @@ encodeRecord state r =
         recordElement ( key, val ) =
             let
                 newState =
-                    { state | prefix = True, col = state.col + state.indent }
+                    { state | prefix = False, col = state.col + state.indent }
+
+                encodedValue =
+                    internalConvertToString newState val
             in
-            key ++ ":" ++ internalConvertToString newState val
+            key
+                ++ ":"
+                ++ (if String.startsWith "\n" encodedValue then
+                        encodedValue
+
+                    else
+                        " " ++ encodedValue
+                   )
 
         prefix : String
         prefix =

--- a/tests/TestEncoder.elm
+++ b/tests/TestEncoder.elm
@@ -130,6 +130,12 @@ suite =
                                 [ [ [ 1, 2 ] ], [ [ 3, 4 ] ] ]
                             )
                         )
+            , Test.test "Empty sub-list" <|
+                \_ ->
+                    Expect.equal "test: []"
+                        (Encode.toString 2
+                            (Encode.record [ ( "test", Encode.list Encode.int [] ) ])
+                        )
             ]
         , Test.describe "Dicts"
             [ Test.test "Empty dict" <|
@@ -351,6 +357,12 @@ suite =
                     in
                     Expect.equal expected
                         (Encode.toString 2 encoder)
+            , Test.test "Empty sub-record" <|
+                \_ ->
+                    Expect.equal "test: {}"
+                        (Encode.toString 2
+                            (Encode.record [ ( "test", Encode.record [] ) ])
+                        )
             ]
         , Test.describe "A Document"
             [ Test.test "A document containing an int" <|


### PR DESCRIPTION
Nested record element values that do not immediately begin with a newline character must have a space between the colon (after the key) and the encoded value.

E.g. YAML interprets this as a string:

```
test:[]
```

But this as a record containing a single key ("test") with a value being an empty list:

```
test: []
```

Closes #32 

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000 by @MyGithubTag)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
