### PR TITLE
Carry explicit encoding context along as we encode values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Bumped Github action dependency versions ([#34](https://github.com/MaybeJustJames/yaml/pull/34))
+- Fix list of record encoding bug #29 ([#35](https://github.com/MaybeJustJames/yaml/pull/35))
 
 ## [2.1.3]
 ### Fixed

--- a/src/Yaml/Encode.elm
+++ b/src/Yaml/Encode.elm
@@ -50,8 +50,8 @@ import Yaml.Parser.Ast exposing (Value(..))
 -}
 type alias EncoderState =
     { col : Int -- Current column
-    , indent : Int -- Encoder indent level
-    , prefix : Bool -- prefix encoder output
+    , indent : Int -- Encoder indent amouont
+    , inRecord : Bool -- Encoding context (in a record or not)
     }
 
 
@@ -61,7 +61,7 @@ initState : Int -> EncoderState
 initState indent =
     { col = 0
     , indent = indent
-    , prefix = False
+    , inRecord = False
     }
 
 
@@ -69,6 +69,13 @@ initState indent =
 -}
 type Encoder
     = Encoder (EncoderState -> String)
+
+
+{-| Encoding context
+-}
+type Context
+    = Oneline
+    | Multiline
 
 
 
@@ -82,7 +89,7 @@ resulting string.
 
     toString 0 (int 4) --> "4"
 
-    toString 0 (list int [ 1, 2, 3 ]) --> "[1,2,3]"
+    toString 0 (list int [ 1, 2, 3 ]) --> "[1, 2, 3]"
 
     toString 2 (list int [ 1, 2, 3 ])
     --> "- 1\n- 2\n- 3"
@@ -107,6 +114,9 @@ internalConvertToString state (Encoder encoderFn) =
 
 
 -- PRIMITIVES
+-- Primitive values care about their encoding context because records can be
+-- encoded with a single space after the colon if the value is primitive or
+-- an inline list or record, otherwise a newline is required.
 
 
 {-| Encode a `String` into a YAML string.
@@ -119,9 +129,7 @@ internalConvertToString state (Encoder encoderFn) =
 string : String -> Encoder
 string s =
     Encoder
-        (\state ->
-            prefixed " " state s
-        )
+        (withContext Oneline s)
 
 
 {-| Encode an `Int` into a YAML int.
@@ -136,10 +144,7 @@ string s =
 int : Int -> Encoder
 int i =
     Encoder
-        (\state ->
-            String.fromInt i
-                |> prefixed " " state
-        )
+        (withContext Oneline (String.fromInt i))
 
 
 {-| Encode a `Float` into a YAML float.
@@ -163,28 +168,26 @@ int i =
 -}
 float : Float -> Encoder
 float f =
+    let
+        sign =
+            if f < 0 then
+                "-"
+
+            else
+                ""
+
+        val =
+            if isNaN f then
+                ".nan"
+
+            else if isInfinite f then
+                sign ++ ".inf"
+
+            else
+                String.fromFloat f
+    in
     Encoder
-        (\state ->
-            let
-                sign =
-                    if f < 0 then
-                        "-"
-
-                    else
-                        ""
-
-                val =
-                    if isNaN f then
-                        ".nan"
-
-                    else if isInfinite f then
-                        sign ++ ".inf"
-
-                    else
-                        String.fromFloat f
-            in
-            prefixed " " state val
-        )
+        (withContext Oneline val)
 
 
 {-| Encode a `Bool` into a YAML bool.
@@ -197,15 +200,13 @@ float f =
 bool : Bool -> Encoder
 bool b =
     Encoder
-        (\state ->
-            prefixed " "
-                state
-                (if b then
-                    "true"
+        (withContext Oneline
+            (if b then
+                "true"
 
-                 else
-                    "false"
-                )
+             else
+                "false"
+            )
         )
 
 
@@ -219,10 +220,7 @@ bool b =
 -}
 null : Encoder
 null =
-    Encoder
-        (\state ->
-            prefixed " " state "null"
-        )
+    Encoder (withContext Oneline "null")
 
 
 {-| Encode a `Value` as produced by `Yaml.Decode.value`
@@ -265,7 +263,7 @@ value val =
 {-| Encode a `List` into a YAML list.
 
     toString 0 (list float [1.1, 2.2, 3.3])
-    --> "[1.1,2.2,3.3]"
+    --> "[1.1, 2.2, 3.3]"
 
     toString 2 (list string ["a", "b"])
     --> "- a\n- b"
@@ -276,15 +274,15 @@ list encode l =
     Encoder
         (\state ->
             if List.isEmpty l then
-                "[]"
+                withContext Oneline "[]" state
 
             else
                 case state.indent of
                     0 ->
-                        encodeInlineList encode l
+                        withContext Oneline (encodeInlineList encode l) state
 
                     _ ->
-                        encodeList encode state l
+                        withContext Multiline (encodeList encode state l) state
         )
 
 
@@ -292,7 +290,7 @@ encodeInlineList : (a -> Encoder) -> List a -> String
 encodeInlineList encode l =
     "["
         ++ (List.map (encode >> toString 0) l
-                |> String.join ","
+                |> String.join ", "
            )
         ++ "]"
 
@@ -300,30 +298,22 @@ encodeInlineList encode l =
 encodeList : (a -> Encoder) -> EncoderState -> List a -> String
 encodeList encode state l =
     let
+        newState : EncoderState
+        newState =
+            { state
+                | col = state.col + state.indent
+                , inRecord = False
+            }
+
         listElement : a -> String
         listElement val =
-            "-"
-                ++ (internalConvertToString
-                        { state | col = state.col + state.indent, prefix = True }
-                        << encode
-                   )
+            "- "
+                ++ String.repeat (state.indent - 2) " "
+                ++ (internalConvertToString newState << encode)
                     val
-
-        prefix : String
-        prefix =
-            if state.prefix then
-                "\n"
-
-            else
-                ""
-
-        indentAfter : String -> String
-        indentAfter s =
-            s ++ String.repeat state.col " "
     in
     List.map listElement l
-        |> String.join (indentAfter "\n")
-        |> String.append (indentAfter prefix)
+        |> String.join (indentAfter state "\n")
 
 
 {-| Encode a `Dict` into a YAML record.
@@ -351,15 +341,15 @@ dict key val r =
     Encoder
         (\state ->
             if Dict.isEmpty r then
-                "{}"
+                withContext Oneline "{}" state
 
             else
                 case state.indent of
                     0 ->
-                        encodeInlineDict key val r
+                        withContext Oneline (encodeInlineDict key val r) state
 
                     _ ->
-                        encodeDict key val state r
+                        withContext Multiline (encodeDict key val state r) state
         )
 
 
@@ -374,7 +364,7 @@ encodeInlineDict key val r =
                 |> List.map (\( fst, snd ) -> key fst ++ ": " ++ snd)
     in
     "{"
-        ++ (stringify r |> String.join ",")
+        ++ (stringify r |> String.join ", ")
         ++ "}"
 
 
@@ -385,27 +375,15 @@ encodeDict key val state r =
         recordElement ( key_, val_ ) =
             let
                 newState =
-                    { state | prefix = True, col = state.col + state.indent }
+                    { state | inRecord = True, col = state.col + state.indent }
             in
-            key key_ ++ ":" ++ (internalConvertToString newState << val) val_
-
-        prefix : String
-        prefix =
-            if state.prefix then
-                "\n"
-
-            else
-                ""
-
-        indentAfter : String -> String
-        indentAfter s =
-            s ++ String.repeat state.col " "
+            key key_
+                ++ ":"
+                ++ (internalConvertToString newState << val) val_
     in
-    r
-        |> Dict.toList
+    Dict.toList r
         |> List.map recordElement
-        |> String.join (indentAfter "\n")
-        |> String.append (indentAfter prefix)
+        |> String.join (indentAfter state "\n")
 
 
 {-| Encode a YAML record.
@@ -414,7 +392,7 @@ encodeDict key val state r =
                        , ( "height", int 187)
                        ]
                )
-    --> "{name: Sally,height: 187}"
+    --> "{name: Sally, height: 187}"
 
     toString 2 (record [ ( "foo", int 42 )
                        , ( "bar", float 3.14 )
@@ -428,15 +406,15 @@ record r =
     Encoder
         (\state ->
             if List.isEmpty r then
-                "{}"
+                withContext Oneline "{}" state
 
             else
                 case state.indent of
                     0 ->
-                        encodeInlineRecord r
+                        withContext Oneline (encodeInlineRecord r) state
 
                     _ ->
-                        encodeRecord state r
+                        withContext Multiline (encodeRecord state r) state
         )
 
 
@@ -451,7 +429,7 @@ encodeInlineRecord r =
                 )
                 vals
     in
-    "{" ++ (stringify r |> String.join ",") ++ "}"
+    "{" ++ (stringify r |> String.join ", ") ++ "}"
 
 
 encodeRecord : EncoderState -> List ( String, Encoder ) -> String
@@ -461,36 +439,21 @@ encodeRecord state r =
         recordElement ( key, val ) =
             let
                 newState =
-                    { state | prefix = False, col = state.col + state.indent }
+                    { state | inRecord = True, col = state.col + state.indent }
 
                 encodedValue =
                     internalConvertToString newState val
             in
             key
                 ++ ":"
-                ++ (if String.startsWith "\n" encodedValue then
-                        encodedValue
-
-                    else
-                        " " ++ encodedValue
-                   )
-
-        prefix : String
-        prefix =
-            if state.prefix then
-                "\n"
-
-            else
-                ""
-
-        indentAfter : String -> String
-        indentAfter s =
-            s ++ String.repeat state.col " "
+                ++ encodedValue
     in
-    r
-        |> List.map recordElement
-        |> String.join (indentAfter "\n")
-        |> String.append (indentAfter prefix)
+    List.map recordElement r
+        |> String.join (indentAfter state "\n")
+
+
+
+--|> String.append (indentAfter state (prefixed "\n" state ""))
 
 
 {-| Encode a YAML document
@@ -524,15 +487,6 @@ document val =
 -- HELPERS
 
 
-prefixed : String -> EncoderState -> String -> String
-prefixed prefix state val =
-    if state.prefix then
-        prefix ++ val
-
-    else
-        val
-
-
 anchor : String -> (Value -> Encoder) -> Value -> Encoder
 anchor name encode val =
     Encoder
@@ -547,3 +501,21 @@ alias_ name =
         (\_ ->
             "*" ++ name
         )
+
+
+indentAfter : EncoderState -> String -> String
+indentAfter state s =
+    s ++ String.repeat state.col " "
+
+
+withContext : Context -> String -> EncoderState -> String
+withContext context val state =
+    case ( context, state.inRecord ) of
+        ( Oneline, True ) ->
+            " " ++ val
+
+        ( Multiline, True ) ->
+            "\n" ++ String.repeat state.col " " ++ val
+
+        _ ->
+            val


### PR DESCRIPTION
This allows us to correctly encode values with different indentation in lists and records. As a side-effect of this change, the way indentation is rendered has changed such that there are `indent - 1` spaces between multiline list markers and list elements now. I believe this is most consistent.

This commit adds tests to ensure that encoding of records in lists (both inline and not inline) are correct.

Closes #29

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000 by @MyGithubTag)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
