### PR TITLE
add support for literal multi-line strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Added support for literal multi-line strings ([#36](https://github.com/MaybeJustJames/yaml/pull/36))
+- Added support for literal multi-line strings ([#36](https://github.com/MaybeJustJames/yaml/pull/36) by [lovebug356](https://github.com/lovebug356))
 
 ## [2.1.4]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Added support for literal multi-line strings ([#36](https://github.com/MaybeJustJames/yaml/pull/36))
 
 ## [2.1.4]
 ### Changed

--- a/src/Yaml/Parser.elm
+++ b/src/Yaml/Parser.elm
@@ -340,7 +340,7 @@ quotedString indent =
         withQuote quote =
             P.oneOf
                 [ recordProperty indent quote
-                , P.succeed (Ast.String_ <| U.postProcessString quote)
+                , P.succeed (Ast.String_ <| U.postProcessFoldedString quote)
                 ]
     in
     P.succeed identity

--- a/tests/TestParser.elm
+++ b/tests/TestParser.elm
@@ -59,7 +59,6 @@ suite =
                     Ast.Float_ x
         , Test.test "a single-quoted string" <|
             \_ ->
-                -- TODO is this right?
                 expectValue """'hey
           i am a 
 
@@ -109,6 +108,33 @@ suite =
             """
                 <|
                     Ast.String_ "how does one teach self-respect? how does one teach curiousity? if you have the answers, call me"
+        , Test.test
+            "a literal multi-line string"
+          <|
+            \_ ->
+                expectValue "|\n literal\n \ttext" <|
+                    Ast.String_ "literal\n\ttext"
+        , Test.test "a record with literal string" <|
+            \_ ->
+                expectValue
+                    """
+            aaa: |
+                hello
+                world
+            """
+                <|
+                    Ast.Record_ (Dict.fromList [ ( "aaa", Ast.String_ "hello\nworld" ) ])
+        , Test.test "a record with literal string with empty lines" <|
+            \_ ->
+                expectValue
+                    """
+            aaa: |
+                hello
+
+                world
+            """
+                <|
+                    Ast.Record_ (Dict.fromList [ ( "aaa", Ast.String_ "hello\n\nworld" ) ])
         , Test.test "a empty inline list" <|
             \_ ->
                 expectValue "[]" <|


### PR DESCRIPTION
Added support for the literal multi-line strings as described in the yaml specification:
https://yaml.org/spec/1.2.2/#812-literal-style.

Closes #31 