### PR TITLE
Allow trailing comma in inline lists

### DIFF
--- a/src/Yaml/Parser.elm
+++ b/src/Yaml/Parser.elm
@@ -265,8 +265,14 @@ listInlineString =
 listInlineNext : List Ast.Value -> Ast.Value -> P.Parser (P.Step (List Ast.Value) (List Ast.Value))
 listInlineNext elements element =
     P.oneOf
-        [ P.succeed (listInlineOnMore elements element)
-            |. P.chompIf U.isComma
+        [ P.succeed identity
+            |. P.symbol ","
+            |. U.whitespace
+            |= P.oneOf
+                [ P.succeed (listInlineOnDone elements element)
+                    |. P.symbol "]"
+                , P.succeed (listInlineOnMore elements element)
+                ]
         , P.succeed (listInlineOnDone elements element)
             |. P.chompIf U.isListEnd
         ]

--- a/tests/TestParser.elm
+++ b/tests/TestParser.elm
@@ -197,6 +197,14 @@ suite =
            ccc 
            ]""" <|
                     Ast.List_ [ Ast.String_ "aaa", Ast.String_ "bbb", Ast.String_ "ccc ccc\n           ccc" ]
+        , Test.test "an inline list with a trailing comma" <|
+            \_ ->
+                expectValue "[ aaa, bbb, ]" <|
+                    Ast.List_ [ Ast.String_ "aaa", Ast.String_ "bbb" ]
+        , Test.test "an inline list with a trailing explicit null" <|
+            \_ ->
+                expectValue "[ aaa, bbb, null ]" <|
+                    Ast.List_ [ Ast.String_ "aaa", Ast.String_ "bbb", Ast.Null_ ]
         , Test.test "an inline list with an inline list inside" <|
             \_ ->
                 expectValue "[ aaa, [ bbb, aaa, ccc ], ccc ]" <|


### PR DESCRIPTION
Allow trailing comma in inline lists according to [UDR7](https://matrix.yaml.info/details/UDR7.html).

Closes #41 

