### PR TITLE
Expose `Parser.DeadEnd`s

### DIFF
--- a/src/Yaml/Parser.elm
+++ b/src/Yaml/Parser.elm
@@ -1,4 +1,4 @@
-module Yaml.Parser exposing (Value, fromString, parser)
+module Yaml.Parser exposing (Value, fromString, parse, parser)
 
 import Dict exposing (Dict)
 import Parser as P exposing ((|.), (|=))
@@ -88,6 +88,13 @@ problemToString p =
 fromString : String -> Result String Ast.Value
 fromString =
     P.run parser >> Result.mapError deadEndsToString >> Result.map deref
+
+
+{-| -}
+parse : String -> Result (List P.DeadEnd) Ast.Value
+parse input =
+    P.run parser input
+        |> Result.map deref
 
 
 {-| -}

--- a/tests/Expectations.elm
+++ b/tests/Expectations.elm
@@ -18,7 +18,7 @@ expectCloseTo expected got =
 
 {-| Utility function that checks the failure mode of a Decoder
 -}
-expectFail : String -> Result Decode.Error a -> Expect.Expectation
+expectFail : String -> Result (Decode.Error e) a -> Expect.Expectation
 expectFail expected got =
     Expect.equal (Err (Decode.Decoding expected)) got
 

--- a/tests/TestDecoder.elm
+++ b/tests/TestDecoder.elm
@@ -401,6 +401,6 @@ suite =
 
 {-| Utility function that sets up a test.
 -}
-given : String -> Yaml.Decoder a -> Result Yaml.Error a
+given : String -> Yaml.Decoder a -> Result (Yaml.Error String) a
 given input decoder =
     Yaml.fromString decoder input


### PR DESCRIPTION
**Description of the change**

Expose an API that allows the user to access the raw `Parser.DeadEnd`s as per #44.

This is marked as draft because it would be a major update, and I don't like that. At the same time I also don't like the idea of creating a separate error type?

Let me know if you see a better path.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000 by @MyGithubTag)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [X] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
